### PR TITLE
Potential fix for code scanning alert no. 20: Bad HTML filtering regexp

### DIFF
--- a/packages/ui-templates/lib/render.ts
+++ b/packages/ui-templates/lib/render.ts
@@ -126,7 +126,7 @@ export const RenderPlugin = () => {
           .match(/<body[^>]*>([\s\S]*)<\/body>/)?.[0]
           .replace(/(?<=<\/|<)body/g, 'div')
           .replace(/messages\./g, '')
-          .replace(/<script[^>]*>([\s\S]*?)<\/script>/g, '')
+          .replace(/<script[^>]*>([\s\S]*?)<\/script>/gi, '')
           .replace(/<a href="(\/[^"]*)"([^>]*)>([\s\S]*)<\/a>/g, '<NuxtLink to="$1"$2>\n$3\n</NuxtLink>')
 
           .replace(/<([^>]+) ([a-z]+)="([^"]*)(\{\{\s*(\w+)\s*\}\})([^"]*)"([^>]*)>/g, '<$1 :$2="`$3${$5}$6`"$7>')
@@ -147,7 +147,7 @@ export const RenderPlugin = () => {
         }).replace(/@media[^{]*\{\}/g, '')
 
         const inlineScripts: string[] = []
-        for (const [_, i] of html.matchAll(/<script>([\s\S]*?)<\/script>/g)) {
+        for (const [_, i] of html.matchAll(/<script>([\s\S]*?)<\/script>/gi)) {
           if (i && !i.includes('const t=document.createElement("link")')) {
             inlineScripts.push(i)
           }


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-up/security/code-scanning/20](https://github.com/deadjdona/nuxt-up/security/code-scanning/20)

To fix the issue, the regular expression should be updated to match `<script>` tags in a case-insensitive manner. This can be achieved by adding the `i` flag to the regex, which makes it case-insensitive. Additionally, it is recommended to use a well-tested library like `DOMPurify` for sanitization to handle edge cases comprehensively. However, since the codebase appears to rely on custom regex-based sanitization, the immediate fix will focus on correcting the regex.

Changes will be made to the regex on line 150 and similar regex patterns elsewhere in the file to ensure they match `<script>` tags regardless of case.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
