### PR TITLE
Potential fix for code scanning alert no. 1153: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue-labelled.yml
+++ b/.github/workflows/issue-labelled.yml
@@ -10,6 +10,8 @@ jobs:
     name: Convert labels to issue types
     runs-on: ubuntu-slim
     if: github.repository == 'nuxt/nuxt'
+    permissions:
+      issues: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/nuxt-up/security/code-scanning/1153](https://github.com/deadjdona/nuxt-up/security/code-scanning/1153)

To fix the problem, add an explicit `permissions` block to the `convert-label-to-issue-type` job that grants only the scopes it needs. Since the script only updates issues and removes issue labels, it needs `issues: write` and can avoid broader scopes such as `contents: write`. This matches the pattern already used by the `transfer-spam` and `needs-reproduction` jobs in the same file.

Concretely, in `.github/workflows/issue-labelled.yml`, under `jobs: convert-label-to-issue-type:`, add a `permissions:` section at the same indentation level as `runs-on` and `if`, and set `issues: write`. No imports or additional methods are needed since this is a YAML configuration change only, and it does not affect the existing functionality of the script; it simply documents and constrains the token permissions to the minimum necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
